### PR TITLE
Elm 0.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a module for routing single-page-apps in Elm, building on the
 [`elm-lang/navigation`](http://package.elm-lang.org/packages/elm-lang/navigation/latest)
 package. It is the successor to elm-route-hash:
 
-* now compatible with Elm 0.17, and
+* now compatible with Elm 0.18, and
 
 * no longer limited to working only with the hash (hence the name change).
 
@@ -88,42 +88,28 @@ use elm-route-url, you don't have to.
 ### Mapping location changes to messages our app can respond to
 
 If you use the official [navigation](http://package.elm-lang.org/packages/elm-lang/navigation/latest)
-package directly, then you are asked to implement a function that acts
-sort of like `update`, but with a different signature -- it looks like this:
+package in Elm 0.18 directly, the `Navgation.program` differs from the
+standard `Html.program` in two ways:
 
-```elm
-urlUpdate : data -> model -> (model, Cmd msg)
-```
+First, you are asked to implement an argument
+to `Navigation.program` that converts a `Location` to a message
+whenever the URL changes.
 
-(The `data` here is some data which is the result of parsing the `Location`.)
+Second, the `Navigation.program` takes an init function that
+takes a `Location` as an argument. This lets you use the URL on the first frame.
 
-This, too, can be made to work. However, it is a bit odd that you are now
-permitted to bypass your `update` function and your `Message` type. It used to
-be true, in the Elm architecture, that:
-
-* the only way to change state was by sending a `Message`
-* the only place you processed messages was in your `update` function
-
-Yet now, the design of the `Navigation` module allows you to change state in
-your `urlUpdate` function, bypassing your own `Message` type and `update`
-function entirely. This is potentially problematic, because it makes reasoning
-about what your app is doing harder.
-
-To avoid this, elm-route-url asks you to implement a function with a
-different signature:
+In elm-route-url, this functionality for both of these is handled by asking
+you to implement a function with a different signature:
 
 ```elm
 location2messages : Location -> List Message
 ```
 
-Using this approach, your url-handling code has a limited scope. Instead of
-doing possibly anything, its work is limited to translating location changes to
-messages that your app could respond to even without any URLs being involved.
-
-Thus, elm-route-url maintains the principle that all changes to the model are
-done through your `update` function. Besides making it eaiser to reason about
-what your app does, this also avoids forcing you to make certain changes via
-the URL -- you simply use the equivalent messages instead.
+`location2messages` will be called when the underlying `Navigation.program`
+`init` method is invoked, so you don't need to change that in your
+program's code. And of course `location2messages` will also be called every
+time the location is changed externally (not from a state change that
+generated a new location via `delta2url`).
 
 
 ## API
@@ -153,8 +139,8 @@ should migrate to using `RouteUrl` at an appropriate moment.
 ## Examples
 
 I've included [example code](https://github.com/rgrempel/elm-route-hash/tree/master/examples/elm-architecture-tutorial)
-which turns the old Elm Architecture Tutorial into a single-page app. I've
-included three variations:
+which turns the old Elm Architecture Tutorial (upgraded to Elm 0.18) into
+a single-page app. I've included three variations:
 
 * Using the new `RouteUrl` API with the full path.
 * Using the new `RouteUrl` API with the hash only.

--- a/elm-package.json
+++ b/elm-package.json
@@ -1,5 +1,5 @@
 {
-    "version": "2.0.0",
+    "version": "3.0.0",
     "summary": "Router for single-page-apps in Elm",
     "repository": "https://github.com/rgrempel/elm-route-url.git",
     "license": "BSD3",
@@ -8,15 +8,14 @@
     ],
     "exposed-modules": [
         "RouteUrl",
-        "RouteHash",
         "RouteUrl.Builder"
     ],
     "dependencies": {
-        "elm-lang/core": "4.0.1 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
-        "sporto/erl": "9.0.1 <= v < 10.0.0"
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.0.0 <= v < 3.0.0",
+        "sporto/erl": "10.0.2 <= v < 11.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/elm-package.json
+++ b/elm-package.json
@@ -11,6 +11,7 @@
         "RouteUrl.Builder"
     ],
     "dependencies": {
+        "ccapndave/elm-update-extra": "2.3.1 <= v < 3.0.0",
         "elm-lang/core": "5.0.0 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",
         "elm-lang/http": "1.0.0 <= v < 2.0.0",

--- a/examples/elm-architecture-tutorial/Example1/Counter.elm
+++ b/examples/elm-architecture-tutorial/Example1/Counter.elm
@@ -10,18 +10,26 @@ import String exposing (toInt)
 
 -- MODEL
 
-type alias Model = Int
+
+type alias Model =
+    Int
+
 
 
 -- Added from Main.elm
+
+
 init : Model
-init = 0
+init =
+    0
+
 
 
 -- UPDATE
-
 -- We add a Set action for the advanced example, so that we
 -- can restore a particular bookmarked state.
+
+
 type Action
     = Increment
     | Decrement
@@ -30,52 +38,68 @@ type Action
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Increment -> model + 1
-    Decrement -> model - 1
-    Set value -> value
+    case action of
+        Increment ->
+            model + 1
+
+        Decrement ->
+            model - 1
+
+        Set value ->
+            value
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  div []
-    [ button [ onClick Decrement ] [ text "-" ]
-    , div [ countStyle ] [ text (toString model) ]
-    , button [ onClick Increment ] [ text "+" ]
-    ]
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , div [ countStyle ] [ text (toString model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]
 
 
 countStyle : Attribute any
 countStyle =
-  style
-    [ ("font-size", "20px")
-    , ("font-family", "monospace")
-    , ("display", "inline-block")
-    , ("width", "50px")
-    , ("text-align", "center")
-    ]
+    style
+        [ ( "font-size", "20px" )
+        , ( "font-family", "monospace" )
+        , ( "display", "inline-block" )
+        , ( "width", "50px" )
+        , ( "text-align", "center" )
+        ]
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
 -- construct a table of contents. Sometimes, you might have a function of this
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction.
+
+
 title : String
-title = "Counter"
+title =
+    "Counter"
+
 
 
 -- Routing (Old API)
-
 -- For delta2update, we provide our state as the value for the URL
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     Just <|
-        RouteHash.set [toString current]
+        RouteHash.set [ toString current ]
+
 
 
 -- For location2action, we generate an action that will restore our state
+
+
 location2action : List String -> List Action
 location2action list =
     case list of
@@ -94,13 +118,15 @@ location2action list =
             []
 
 
+
 -- Routing (New API)
+
 
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
     builder
-    |> replacePath [toString current]
-    |> Just
+        |> replacePath [ toString current ]
+        |> Just
 
 
 builder2messages : Builder -> List Action

--- a/examples/elm-architecture-tutorial/Example2/Counter.elm
+++ b/examples/elm-architecture-tutorial/Example2/Counter.elm
@@ -1,9 +1,15 @@
-module Example2.Counter exposing
-    ( Model, init
-    , Action, update, view
-    , delta2update, location2action
-    , delta2fragment, fragment2messages
-    )
+module Example2.Counter
+    exposing
+        ( Model
+        , init
+        , Action
+        , update
+        , view
+        , delta2update
+        , location2action
+        , delta2fragment
+        , fragment2messages
+        )
 
 import Html exposing (..)
 import Html.Attributes exposing (style)
@@ -14,17 +20,22 @@ import String exposing (toInt)
 
 -- MODEL
 
-type alias Model = Int
+
+type alias Model =
+    Int
 
 
 init : Int -> Model
-init count = count
+init count =
+    count
+
 
 
 -- UPDATE
-
 -- We add a Set action for the advanced example, so that we
 -- can restore a particular bookmarked state.
+
+
 type Action
     = Increment
     | Decrement
@@ -33,44 +44,56 @@ type Action
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Increment -> model + 1
-    Decrement -> model - 1
-    Set value -> value
+    case action of
+        Increment ->
+            model + 1
+
+        Decrement ->
+            model - 1
+
+        Set value ->
+            value
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  div []
-    [ button [ onClick Decrement ] [ text "-" ]
-    , div [ countStyle ] [ text (toString model) ]
-    , button [ onClick Increment ] [ text "+" ]
-    ]
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , div [ countStyle ] [ text (toString model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]
 
 
 countStyle : Attribute any
 countStyle =
-  style
-    [ ("font-size", "20px")
-    , ("font-family", "monospace")
-    , ("display", "inline-block")
-    , ("width", "50px")
-    , ("text-align", "center")
-    ]
+    style
+        [ ( "font-size", "20px" )
+        , ( "font-family", "monospace" )
+        , ( "display", "inline-block" )
+        , ( "width", "50px" )
+        , ( "text-align", "center" )
+        ]
+
 
 
 -- Routing (Old API)
-
 -- For delta2update, we provide our state as the value for the URL
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     Just <|
-        RouteHash.set [toString current]
+        RouteHash.set [ toString current ]
+
 
 
 -- For location2action, we generate an action that will restore our state
+
+
 location2action : List String -> List Action
 location2action list =
     case list of
@@ -84,19 +107,24 @@ location2action list =
                     []
 
         _ ->
-            -- If nothing provided for this part of the URL, return empty list 
+            -- If nothing provided for this part of the URL, return empty list
             []
 
 
--- Routing (New API)
 
+-- Routing (New API)
 -- We'll just send back a string
+
+
 delta2fragment : Model -> Model -> String
 delta2fragment previous current =
     toString current
 
 
+
 -- We'll just take a string
+
+
 fragment2messages : String -> List Action
 fragment2messages fragment =
     case toInt fragment of

--- a/examples/elm-architecture-tutorial/Example2/CounterPair.elm
+++ b/examples/elm-architecture-tutorial/Example2/CounterPair.elm
@@ -4,12 +4,12 @@ import Example2.Counter as Counter
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Html.App exposing (map)
 import RouteHash exposing (HashUpdate)
 import RouteUrl.Builder exposing (Builder, builder, insertQuery, getQuery)
 
 
 -- MODEL
+
 
 type alias Model =
     { topCounter : Counter.Model
@@ -17,7 +17,10 @@ type alias Model =
     }
 
 
+
 -- Rewrote to move initialization from Main.elm
+
+
 init : Model
 init =
     { topCounter = Counter.init 0
@@ -25,7 +28,9 @@ init =
     }
 
 
+
 -- UPDATE
+
 
 type Action
     = Reset
@@ -35,43 +40,52 @@ type Action
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Reset -> init
+    case action of
+        Reset ->
+            init
 
-    Top act ->
-      { model |
-          topCounter = Counter.update act model.topCounter
-      }
+        Top act ->
+            { model
+                | topCounter = Counter.update act model.topCounter
+            }
 
-    Bottom act ->
-      { model |
-          bottomCounter = Counter.update act model.bottomCounter
-      }
+        Bottom act ->
+            { model
+                | bottomCounter = Counter.update act model.bottomCounter
+            }
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  div []
-    [ map Top (Counter.view model.topCounter)
-    , map Bottom (Counter.view model.bottomCounter)
-    , button [ onClick Reset ] [ text "RESET" ]
-    ]
+    div []
+        [ Html.map Top (Counter.view model.topCounter)
+        , Html.map Bottom (Counter.view model.bottomCounter)
+        , button [ onClick Reset ] [ text "RESET" ]
+        ]
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
 -- construct a table of contents. Sometimes, you might have a function of this
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction.
+
+
 title : String
-title = "Pair of Counters"
+title =
+    "Pair of Counters"
+
 
 
 -- Routing (Old API)
-
 -- To encode state in the URL, we'll just delegate & concatenate
 -- This will produce partial URLs like /6/7
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     -- The implementation is not especially elegant ... perhaps
@@ -91,8 +105,8 @@ location2action list =
         -- We're expecting two things that we can delegate down ...
         top :: bottom :: rest ->
             List.concat
-                [ List.map Top <| Counter.location2action [top]
-                , List.map Bottom <| Counter.location2action [bottom]
+                [ List.map Top <| Counter.location2action [ top ]
+                , List.map Bottom <| Counter.location2action [ bottom ]
                 ]
 
         -- If we don't have what we expect, then no actions
@@ -100,15 +114,17 @@ location2action list =
             []
 
 
--- Routing (New API)
 
+-- Routing (New API)
 -- We'll put the two counters in the query parameters, just for fun
+
+
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
     builder
-    |> insertQuery "top" (Counter.delta2fragment previous.topCounter current.topCounter)
-    |> insertQuery "bottom" (Counter.delta2fragment previous.bottomCounter current.bottomCounter)
-    |> Just
+        |> insertQuery "top" (Counter.delta2fragment previous.topCounter current.topCounter)
+        |> insertQuery "bottom" (Counter.delta2fragment previous.bottomCounter current.bottomCounter)
+        |> Just
 
 
 builder2messages : Builder -> List Action
@@ -116,13 +132,12 @@ builder2messages builder =
     let
         left =
             getQuery "top" builder
-            |> Maybe.map ((List.map Top) << Counter.fragment2messages)
+                |> Maybe.map ((List.map Top) << Counter.fragment2messages)
 
         right =
             getQuery "bottom" builder
-            |> Maybe.map ((List.map Bottom) << Counter.fragment2messages)
-
+                |> Maybe.map ((List.map Bottom) << Counter.fragment2messages)
     in
         [ left, right ]
-        |> List.filterMap identity
-        |> List.concat
+            |> List.filterMap identity
+            |> List.concat

--- a/examples/elm-architecture-tutorial/Example3/Counter.elm
+++ b/examples/elm-architecture-tutorial/Example3/Counter.elm
@@ -7,42 +7,54 @@ import Html.Events exposing (onClick)
 
 -- MODEL
 
-type alias Model = Int
+
+type alias Model =
+    Int
 
 
 init : Int -> Model
-init count = count
+init count =
+    count
+
 
 
 -- UPDATE
 
-type Action = Increment | Decrement
+
+type Action
+    = Increment
+    | Decrement
 
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Increment -> model + 1
-    Decrement -> model - 1
+    case action of
+        Increment ->
+            model + 1
+
+        Decrement ->
+            model - 1
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  div []
-    [ button [ onClick Decrement ] [ text "-" ]
-    , div [ countStyle ] [ text (toString model) ]
-    , button [ onClick Increment ] [ text "+" ]
-    ]
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , div [ countStyle ] [ text (toString model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]
 
 
 countStyle : Attribute any
 countStyle =
-  style
-    [ ("font-size", "20px")
-    , ("font-family", "monospace")
-    , ("display", "inline-block")
-    , ("width", "50px")
-    , ("text-align", "center")
-    ]
+    style
+        [ ( "font-size", "20px" )
+        , ( "font-family", "monospace" )
+        , ( "display", "inline-block" )
+        , ( "width", "50px" )
+        , ( "text-align", "center" )
+        ]

--- a/examples/elm-architecture-tutorial/Example3/CounterList.elm
+++ b/examples/elm-architecture-tutorial/Example3/CounterList.elm
@@ -4,7 +4,6 @@ import Example3.Counter as Counter
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Html.App exposing (map)
 import RouteHash exposing (HashUpdate)
 import RouteUrl.Builder exposing (Builder, builder, path, replacePath)
 import Result.Extra
@@ -13,12 +12,15 @@ import String
 
 -- MODEL
 
+
 type alias Model =
     { counters : List ( ID, Counter.Model )
     , nextID : ID
     }
 
-type alias ID = Int
+
+type alias ID =
+    Int
 
 
 init : Model
@@ -28,10 +30,12 @@ init =
     }
 
 
--- UPDATE
 
+-- UPDATE
 -- Add an action for the advanced example to set our
 -- state from a `List Int`
+
+
 type Action
     = Insert
     | Remove
@@ -41,77 +45,97 @@ type Action
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Insert ->
-      let newCounter = ( model.nextID, Counter.init 0 )
-          newCounters = model.counters ++ [ newCounter ]
-      in
-          { model |
-              counters = newCounters,
-              nextID = model.nextID + 1
-          }
+    case action of
+        Insert ->
+            let
+                newCounter =
+                    ( model.nextID, Counter.init 0 )
 
-    Remove ->
-      { model | counters = List.drop 1 model.counters }
+                newCounters =
+                    model.counters ++ [ newCounter ]
+            in
+                { model
+                    | counters = newCounters
+                    , nextID = model.nextID + 1
+                }
 
-    Modify id counterAction ->
-      let updateCounter (counterID, counterModel) =
-            if counterID == id
-                then (counterID, Counter.update counterAction counterModel)
-                else (counterID, counterModel)
-      in
-          { model | counters = List.map updateCounter model.counters }
+        Remove ->
+            { model | counters = List.drop 1 model.counters }
 
-    Set list ->
-        let
-            counters =
-                List.indexedMap (\index item ->
-                    (index, Counter.init item)
-                ) list
+        Modify id counterAction ->
+            let
+                updateCounter ( counterID, counterModel ) =
+                    if counterID == id then
+                        ( counterID, Counter.update counterAction counterModel )
+                    else
+                        ( counterID, counterModel )
+            in
+                { model | counters = List.map updateCounter model.counters }
 
-        in
-            { counters = counters
-            , nextID = List.length counters
-            }
+        Set list ->
+            let
+                counters =
+                    List.indexedMap
+                        (\index item ->
+                            ( index, Counter.init item )
+                        )
+                        list
+            in
+                { counters = counters
+                , nextID = List.length counters
+                }
+
+
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  let
-      counters = List.map viewCounter model.counters
-      remove = button [ onClick Remove ] [ text "Remove" ]
-      insert = button [ onClick Insert ] [ text "Add" ]
+    let
+        counters =
+            List.map viewCounter model.counters
 
-  in
-      div [] ([remove, insert] ++ counters)
+        remove =
+            button [ onClick Remove ] [ text "Remove" ]
+
+        insert =
+            button [ onClick Insert ] [ text "Add" ]
+    in
+        div [] ([ remove, insert ] ++ counters)
 
 
-viewCounter : (ID, Counter.Model) -> Html Action
-viewCounter (id, model) =
-  map (Modify id) (Counter.view model)
+viewCounter : ( ID, Counter.Model ) -> Html Action
+viewCounter ( id, model ) =
+    Html.map (Modify id) (Counter.view model)
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
 -- construct a table of contents. Sometimes, you might have a function of this
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction.
+
+
 title : String
-title = "List of Counters"
+title =
+    "List of Counters"
+
 
 
 -- Routing (Old API)
-
 -- You could do this in a variety of ways. We'll ignore the ID's, and just
 -- encode the value of each Counter in the list -- so we'll end up with
 -- something like /0/1/5 or whatever. When we recreate that, we won't
 -- necessarily have the same IDs, but that doesn't matter for this example.
 -- If it mattered, we'd have to do this a different way.
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     -- We'll take advantage of the fact that we know that the counter
     -- is just an Int ... no need to be super-modular here.
-    List.map (toString << snd) current.counters
+    List.map (toString << Tuple.second) current.counters
         |> RouteHash.set
         |> Just
 
@@ -122,7 +146,6 @@ location2action list =
         result =
             List.map String.toInt list
                 |> Result.Extra.combine
-
     in
         case result of
             Ok ints ->
@@ -132,15 +155,17 @@ location2action list =
                 []
 
 
+
 -- Routing (New API)
+
 
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
     -- We'll take advantage of the fact that we know that the counter
     -- is just an Int ... no need to be super-modular here.
     builder
-    |> replacePath (List.map (toString << snd) current.counters)
-    |> Just
+        |> replacePath (List.map (toString << Tuple.second) current.counters)
+        |> Just
 
 
 builder2messages : Builder -> List Action
@@ -150,7 +175,6 @@ builder2messages builder =
             path builder
                 |> List.map String.toInt
                 |> Result.Extra.combine
-
     in
         case result of
             Ok ints ->
@@ -158,4 +182,3 @@ builder2messages builder =
 
             Err _ ->
                 []
-

--- a/examples/elm-architecture-tutorial/Example4/Counter.elm
+++ b/examples/elm-architecture-tutorial/Example4/Counter.elm
@@ -3,39 +3,50 @@ module Example4.Counter exposing (Model, init, Action, update, view, viewWithRem
 import Html exposing (..)
 import Html.Attributes exposing (..)
 import Html.Events exposing (..)
-import Html.App exposing (map)
 
 
 -- MODEL
 
-type alias Model = Int
+
+type alias Model =
+    Int
 
 
 init : Int -> Model
-init count = count
+init count =
+    count
+
 
 
 -- UPDATE
 
-type Action = Increment | Decrement
+
+type Action
+    = Increment
+    | Decrement
 
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Increment -> model + 1
-    Decrement -> model - 1
+    case action of
+        Increment ->
+            model + 1
+
+        Decrement ->
+            model - 1
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  div []
-    [ button [ onClick Decrement ] [ text "-" ]
-    , div [ countStyle ] [ text (toString model) ]
-    , button [ onClick Increment ] [ text "+" ]
-    ]
+    div []
+        [ button [ onClick Decrement ] [ text "-" ]
+        , div [ countStyle ] [ text (toString model) ]
+        , button [ onClick Increment ] [ text "+" ]
+        ]
 
 
 type alias Context super =
@@ -46,21 +57,21 @@ type alias Context super =
 
 viewWithRemoveButton : Context super -> Model -> Html super
 viewWithRemoveButton context model =
-  div []
-    [ map context.modify (button [ onClick Decrement ] [ text "-" ])
-    , div [ countStyle ] [ text (toString model) ]
-    , map context.modify (button [ onClick Increment ] [ text "+" ])
-    , div [ countStyle ] []
-    , button [ onClick context.remove ] [ text "X" ]
-    ]
+    div []
+        [ Html.map context.modify (button [ onClick Decrement ] [ text "-" ])
+        , div [ countStyle ] [ text (toString model) ]
+        , Html.map context.modify (button [ onClick Increment ] [ text "+" ])
+        , div [ countStyle ] []
+        , button [ onClick context.remove ] [ text "X" ]
+        ]
 
 
 countStyle : Attribute any
 countStyle =
-  style
-    [ ("font-size", "20px")
-    , ("font-family", "monospace")
-    , ("display", "inline-block")
-    , ("width", "50px")
-    , ("text-align", "center")
-    ]
+    style
+        [ ( "font-size", "20px" )
+        , ( "font-family", "monospace" )
+        , ( "display", "inline-block" )
+        , ( "width", "50px" )
+        , ( "text-align", "center" )
+        ]

--- a/examples/elm-architecture-tutorial/Example4/CounterList.elm
+++ b/examples/elm-architecture-tutorial/Example4/CounterList.elm
@@ -12,12 +12,15 @@ import String
 
 -- MODEL
 
+
 type alias Model =
     { counters : List ( ID, Counter.Model )
     , nextID : ID
     }
 
-type alias ID = Int
+
+type alias ID =
+    Int
 
 
 init : Model
@@ -27,9 +30,11 @@ init =
     }
 
 
--- UPDATE
 
+-- UPDATE
 -- Add an action for the advanced example to set our state from a `list int`
+
+
 type Action
     = Insert
     | Remove ID
@@ -39,54 +44,63 @@ type Action
 
 update : Action -> Model -> Model
 update action model =
-  case action of
-    Insert ->
-      { model |
-          counters = ( model.nextID, Counter.init 0 ) :: model.counters,
-          nextID = model.nextID + 1
-      }
-
-    Remove id ->
-      { model |
-          counters = List.filter (\(counterID, _) -> counterID /= id) model.counters
-      }
-
-    Modify id counterAction ->
-      let updateCounter (counterID, counterModel) =
-            if counterID == id
-                then (counterID, Counter.update counterAction counterModel)
-                else (counterID, counterModel)
-      in
-          { model | counters = List.map updateCounter model.counters }
-
-    Set list ->
-        let
-            counters =
-                List.indexedMap (\index item ->
-                    (index, Counter.init item)
-                ) list
-
-        in
-            { counters = counters
-            , nextID = List.length counters
+    case action of
+        Insert ->
+            { model
+                | counters = ( model.nextID, Counter.init 0 ) :: model.counters
+                , nextID = model.nextID + 1
             }
+
+        Remove id ->
+            { model
+                | counters = List.filter (\( counterID, _ ) -> counterID /= id) model.counters
+            }
+
+        Modify id counterAction ->
+            let
+                updateCounter ( counterID, counterModel ) =
+                    if counterID == id then
+                        ( counterID, Counter.update counterAction counterModel )
+                    else
+                        ( counterID, counterModel )
+            in
+                { model | counters = List.map updateCounter model.counters }
+
+        Set list ->
+            let
+                counters =
+                    List.indexedMap
+                        (\index item ->
+                            ( index, Counter.init item )
+                        )
+                        list
+            in
+                { counters = counters
+                , nextID = List.length counters
+                }
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  let insert = button [ onClick Insert ] [ text "Add" ]
-  in
-      div [] (insert :: List.map viewCounter model.counters)
+    let
+        insert =
+            button [ onClick Insert ] [ text "Add" ]
+    in
+        div [] (insert :: List.map viewCounter model.counters)
 
 
-viewCounter : (ID, Counter.Model) -> Html Action
-viewCounter (id, model) =
-  let context =
-        Counter.Context (Modify id) (Remove id)
-  in
-      Counter.viewWithRemoveButton context model
+viewCounter : ( ID, Counter.Model ) -> Html Action
+viewCounter ( id, model ) =
+    let
+        context =
+            Counter.Context (Modify id) (Remove id)
+    in
+        Counter.viewWithRemoveButton context model
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
@@ -94,22 +108,27 @@ viewCounter (id, model) =
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction. Or, you could track the title in the higher level module,
 -- if you prefer that.
+
+
 title : String
-title = "List of Counters (individually removable)"
+title =
+    "List of Counters (individually removable)"
+
 
 
 -- Routing (Old API)
-
 -- You could do this in a variety of ways. We'll ignore the ID's, and just
 -- encode the value of each Counter in the list -- so we'll end up with
 -- something like /0/1/5 or whatever. When we recreate that, we won't
 -- necessarily have the same IDs, but that doesn't matter for this example.
 -- If it mattered, we'd have to do this a different way.
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     -- We'll take advantage of the fact that we know that the counter
     -- is just an Int ... no need to be super-modular here.
-    List.map (toString << snd) current.counters
+    List.map (toString << Tuple.second) current.counters
         |> RouteHash.set
         |> Just
 
@@ -120,7 +139,6 @@ location2action list =
         result =
             List.map String.toInt list
                 |> Result.Extra.combine
-
     in
         case result of
             Ok ints ->
@@ -130,15 +148,17 @@ location2action list =
                 []
 
 
+
 -- Routing (New API)
+
 
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
     -- We'll take advantage of the fact that we know that the counter
     -- is just an Int ... no need to be super-modular here.
     builder
-    |> replacePath (List.map (toString << snd) current.counters)
-    |> Just
+        |> replacePath (List.map (toString << Tuple.second) current.counters)
+        |> Just
 
 
 builder2messages : Builder -> List Action
@@ -148,7 +168,6 @@ builder2messages builder =
             path builder
                 |> List.map String.toInt
                 |> Result.Extra.combine
-
     in
         case result of
             Ok ints ->

--- a/examples/elm-architecture-tutorial/Example5/RandomGif.elm
+++ b/examples/elm-architecture-tutorial/Example5/RandomGif.elm
@@ -11,10 +11,11 @@ import RouteUrl.Builder exposing (Builder, builder, path, replacePath)
 
 
 -- MODEL
-
 -- For the advanced example, we need to keep track of a status in order to deal
 -- with the fact that a request for a random gif may be in progress when our
 -- location changes. In that case, we want (in effect) to cancel the request.
+
+
 type alias Model =
     { topic : String
     , gifUrl : String
@@ -22,126 +23,159 @@ type alias Model =
     }
 
 
+
 -- Tracks whether we should use or ignore the response from getRandomGif
+
+
 type RequestStatus
-    = Use 
+    = Use
     | Ignore
+
 
 
 -- Rewrote to move initialization from Main.elm.
 --
 -- We start the requestStatus as Use so that we will use the response to the
 -- initial request we issue here.
-init : (Model, Cmd Action)
+
+
+init : ( Model, Cmd Action )
 init =
-  ( Model "funny cats" "assets/waiting.gif" Use
-  , getRandomGif "funny cats"
-  )
+    ( Model "funny cats" "assets/waiting.gif" Use
+    , getRandomGif "funny cats"
+    )
+
 
 
 -- UPDATE
-
 -- We end up needing a separate action for setting the gif from the location,
 -- because in that case we also need to "cancel" any outstanding requests for a
 -- random gif.
+
+
 type Action
     = RequestMore
-    | HttpError Http.Error
-    | NewGif String
+    | NewGif (Result Http.Error String)
     | NewGifFromLocation String
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update action model =
-  case action of
-    RequestMore ->
-      -- When we're explicitly asked to get a random gif, then mark that
-      -- we should use the response.
-      ( { model | requestStatus = Use }
-      , getRandomGif model.topic
-      )
+    case action of
+        RequestMore ->
+            -- When we're explicitly asked to get a random gif, then mark that
+            -- we should use the response.
+            ( { model | requestStatus = Use }
+            , getRandomGif model.topic
+            )
 
-    NewGif url ->
-        case model.requestStatus of
-            Use ->
-                ( { model | gifUrl = url }
-                , Cmd.none
-                )
+        NewGif (Ok url) ->
+            case model.requestStatus of
+                Use ->
+                    ( { model | gifUrl = url }
+                    , Cmd.none
+                    )
 
-            -- This will be set to ignore if our location has changed since
-            -- the request was issued. In that case, we want to ignore the
-            -- result of the randomGif request (which was, of course, async)
-            Ignore ->
-                ( model, Cmd.none )
+                -- This will be set to ignore if our location has changed since
+                -- the request was issued. In that case, we want to ignore the
+                -- result of the randomGif request (which was, of course, async)
+                Ignore ->
+                    ( model, Cmd.none )
 
-    NewGifFromLocation url ->
-        -- When we get the gif from the URL, then ignore any randomGif requests
-        -- that haven't resolved yet.
-        ( { model
+        NewGif (Err _) ->
+            -- Should really show the error ... do nothing for now.
+            ( model, Cmd.none )
+
+        NewGifFromLocation url ->
+            -- When we get the gif from the URL, then ignore any randomGif requests
+            -- that haven't resolved yet.
+            ( { model
                 | gifUrl = url
                 , requestStatus = Ignore
-          }
-        , Cmd.none
-        )
+              }
+            , Cmd.none
+            )
 
-    HttpError error ->
-        -- Should really show the error ... do nothing for now.
-        ( model, Cmd.none )
 
 
 -- VIEW
 
-(=>) = (,)
+
+(=>) =
+    (,)
 
 
 view : Model -> Html Action
 view model =
-  div [ style [ "width" => "200px" ] ]
-    [ h2 [headerStyle] [text model.topic]
-    , div [imgStyle model.gifUrl] []
-    , button [ onClick RequestMore ] [ text "More Please!" ]
-    ]
+    div [ style [ "width" => "200px" ] ]
+        [ h2 [ headerStyle ] [ text model.topic ]
+        , div [ imgStyle model.gifUrl ] []
+        , button [ onClick RequestMore ] [ text "More Please!" ]
+        ]
 
 
 headerStyle : Attribute any
 headerStyle =
-  style
-    [ "width" => "200px"
-    , "text-align" => "center"
-    ]
+    style
+        [ "width" => "200px"
+        , "text-align" => "center"
+        ]
 
 
 imgStyle : String -> Attribute any
 imgStyle url =
-  style
-    [ "display" => "inline-block"
-    , "width" => "200px"
-    , "height" => "200px"
-    , "background-position" => "center center"
-    , "background-size" => "cover"
-    , "background-image" => ("url('" ++ url ++ "')")
-    ]
+    style
+        [ "display" => "inline-block"
+        , "width" => "200px"
+        , "height" => "200px"
+        , "background-position" => "center center"
+        , "background-size" => "cover"
+        , "background-image" => ("url('" ++ url ++ "')")
+        ]
+
 
 
 -- EFFECTS
 
+
+urlWithArgs : String -> List (String, String) -> String
+urlWithArgs baseUrl args =
+  case args of
+    [] ->
+        baseUrl
+
+    _ ->
+        baseUrl ++ "?" ++ String.join "&" (List.map queryPair args)
+
+
+queryPair : (String,String) -> String
+queryPair (key,value) =
+  queryEscape key ++ "=" ++ queryEscape value
+
+
+queryEscape : String -> String
+queryEscape string =
+  String.join "+" (String.split "%20" (Http.encodeUri string))
+
+
 getRandomGif : String -> Cmd Action
 getRandomGif topic =
-  Http.get decodeUrl (randomUrl topic)
-    |> Task.perform HttpError NewGif
+    Http.send NewGif <|
+        Http.get (randomUrl topic) decodeUrl
 
 
 randomUrl : String -> String
 randomUrl topic =
-  Http.url "http://api.giphy.com/v1/gifs/random"
-    [ "api_key" => "dc6zaTOxFJmzC"
-    , "tag" => topic
-    ]
+    urlWithArgs "http://api.giphy.com/v1/gifs/random"
+        [ "api_key" => "dc6zaTOxFJmzC"
+        , "tag" => topic
+        ]
 
 
 decodeUrl : Json.Decoder String
 decodeUrl =
-  Json.at ["data", "image_url"] Json.string
+    Json.at [ "data", "image_url" ] Json.string
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
@@ -149,23 +183,26 @@ decodeUrl =
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction. Or, you could track the title in the higher level module,
 -- if you prefer that.
+
+
 title : String
-title = "Random Gif"
+title =
+    "Random Gif"
+
 
 
 -- Routing (Old API)
-
 -- We'll generate URLs like "/gifUrl"
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
-    if current.gifUrl == (fst init).gifUrl
-        then
-            -- If we're waiting for the first random gif, don't generate an entry ...
-            -- wait for the gif to arrive.
-            Nothing
-
-        else
-            Just (RouteHash.set [current.gifUrl])
+    if current.gifUrl == (Tuple.first init).gifUrl then
+        -- If we're waiting for the first random gif, don't generate an entry ...
+        -- wait for the gif to arrive.
+        Nothing
+    else
+        Just (RouteHash.set [ current.gifUrl ])
 
 
 location2action : List String -> List Action
@@ -180,19 +217,19 @@ location2action list =
             []
 
 
+
 -- Routing (New API)
+
 
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
-    if current.gifUrl == (fst init).gifUrl
-        then
-            -- If we're waiting for the first random gif, don't generate an entry ...
-            -- wait for the gif to arrive.
-            Nothing
-
-        else
-            builder
-            |> replacePath [current.gifUrl]
+    if current.gifUrl == (Tuple.first init).gifUrl then
+        -- If we're waiting for the first random gif, don't generate an entry ...
+        -- wait for the gif to arrive.
+        Nothing
+    else
+        builder
+            |> replacePath [ current.gifUrl ]
             |> Just
 
 

--- a/examples/elm-architecture-tutorial/Example6/RandomGif.elm
+++ b/examples/elm-architecture-tutorial/Example6/RandomGif.elm
@@ -9,11 +9,13 @@ import Task
 import RouteHash exposing (HashUpdate)
 import RouteUrl.Builder exposing (Builder, builder, appendToPath)
 
--- MODEL
 
+-- MODEL
 -- For the advanced example, we need to keep track of a status in order to deal
 -- with the fact that a request for a random gif may be in progress when our
 -- location changes. In that case, we want (in effect) to cancel the request.
+
+
 type alias Model =
     { topic : String
     , gifUrl : String
@@ -21,153 +23,184 @@ type alias Model =
     }
 
 
+
 -- Tracks whether we should use or ignore the response from getRandomGif
+
+
 type RequestStatus
-    = Use 
+    = Use
     | Ignore
+
 
 
 -- We start the requestStatus as Use so that we will use the response to the
 -- initial request we issue here.
-init : String -> (Model, Cmd Action)
+
+
+init : String -> ( Model, Cmd Action )
 init topic =
-  ( Model topic "assets/waiting.gif" Use
-  , getRandomGif topic
-  )
+    ( Model topic "assets/waiting.gif" Use
+    , getRandomGif topic
+    )
+
 
 
 -- UPDATE
-
 -- We end up needing a separate action for setting the gif from the location,
 -- because in that case we also need to "cancel" any outstanding requests for a
 -- random gif.
+
+
 type Action
     = RequestMore
-    | HttpError Http.Error
-    | NewGif String
+    | NewGif (Result Http.Error String)
     | NewGifFromLocation String
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update action model =
-  case action of
-    RequestMore ->
-      -- When we're explicitly asked to get a random gif, then mark that
-      -- we should use the response.
-      ( { model | requestStatus = Use }
-      , getRandomGif model.topic
-      )
+    case action of
+        RequestMore ->
+            -- When we're explicitly asked to get a random gif, then mark that
+            -- we should use the response.
+            ( { model | requestStatus = Use }
+            , getRandomGif model.topic
+            )
 
-    NewGif url ->
-        case model.requestStatus of
-            Use ->
-                ( { model | gifUrl = url }
-                , Cmd.none
-                )
+        NewGif (Ok url) ->
+            case model.requestStatus of
+                Use ->
+                    ( { model | gifUrl = url }
+                    , Cmd.none
+                    )
 
-            -- This will be set to ignore if our location has changed since
-            -- the request was issued. In that case, we want to ignore the
-            -- result of the randomGif request (which was, of course, async)
-            Ignore ->
-                ( model, Cmd.none )
+                -- This will be set to ignore if our location has changed since
+                -- the request was issued. In that case, we want to ignore the
+                -- result of the randomGif request (which was, of course, async)
+                Ignore ->
+                    ( model, Cmd.none )
 
-    NewGifFromLocation url ->
-        -- When we get the gif from the URL, then ignore any randomGif requests
-        -- that haven't resolved yet.
-        ( { model
+        NewGif (Err _) ->
+            -- Should really show the error ... do nothing for now.
+            ( model, Cmd.none )
+
+        NewGifFromLocation url ->
+            -- When we get the gif from the URL, then ignore any randomGif requests
+            -- that haven't resolved yet.
+            ( { model
                 | gifUrl = url
                 , requestStatus = Ignore
-          }
-        , Cmd.none
-        )
+              }
+            , Cmd.none
+            )
 
-    HttpError error ->
-        -- Should really show the error ... do nothing for now.
-        ( model, Cmd.none )
+
 
 -- VIEW
 
-(=>) = (,)
+
+(=>) =
+    (,)
 
 
 view : Model -> Html Action
 view model =
-  div [ style [ "width" => "200px" ] ]
-    [ h2 [headerStyle] [text model.topic]
-    , div [imgStyle model.gifUrl] []
-    , button [ onClick RequestMore ] [ text "More Please!" ]
-    ]
+    div [ style [ "width" => "200px" ] ]
+        [ h2 [ headerStyle ] [ text model.topic ]
+        , div [ imgStyle model.gifUrl ] []
+        , button [ onClick RequestMore ] [ text "More Please!" ]
+        ]
 
 
 headerStyle : Attribute any
 headerStyle =
-  style
-    [ "width" => "200px"
-    , "text-align" => "center"
-    ]
+    style
+        [ "width" => "200px"
+        , "text-align" => "center"
+        ]
 
 
 imgStyle : String -> Attribute any
 imgStyle url =
-  style
-    [ "display" => "inline-block"
-    , "width" => "200px"
-    , "height" => "200px"
-    , "background-position" => "center center"
-    , "background-size" => "cover"
-    , "background-image" => ("url('" ++ url ++ "')")
-    ]
+    style
+        [ "display" => "inline-block"
+        , "width" => "200px"
+        , "height" => "200px"
+        , "background-position" => "center center"
+        , "background-size" => "cover"
+        , "background-image" => ("url('" ++ url ++ "')")
+        ]
+
 
 
 -- EFFECTS
 
+
+urlWithArgs : String -> List (String, String) -> String
+urlWithArgs baseUrl args =
+  case args of
+    [] ->
+        baseUrl
+
+    _ ->
+        baseUrl ++ "?" ++ String.join "&" (List.map queryPair args)
+
+
+queryPair : (String,String) -> String
+queryPair (key,value) =
+  queryEscape key ++ "=" ++ queryEscape value
+
+
+queryEscape : String -> String
+queryEscape string =
+  String.join "+" (String.split "%20" (Http.encodeUri string))
+
+
 getRandomGif : String -> Cmd Action
 getRandomGif topic =
-  Http.get decodeUrl (randomUrl topic)
-    |> Task.perform HttpError NewGif
+    Http.send NewGif <|
+        Http.get (randomUrl topic) decodeUrl
 
 
 randomUrl : String -> String
 randomUrl topic =
-  Http.url "http://api.giphy.com/v1/gifs/random"
-    [ "api_key" => "dc6zaTOxFJmzC"
-    , "tag" => topic
-    ]
+    urlWithArgs "http://api.giphy.com/v1/gifs/random"
+        [ "api_key" => "dc6zaTOxFJmzC"
+        , "tag" => topic
+        ]
 
 
 decodeUrl : Json.Decoder String
 decodeUrl =
-  Json.at ["data", "image_url"] Json.string
+    Json.at [ "data", "image_url" ] Json.string
+
 
 
 -- Routing
-
 -- We'll generate URLs like "/gifUrl". Note that this treats the topic as an
 -- invariant, which it is here ... it can only be supplied on initialization.
 -- If it weren't invariant, we'd need to do something more complex.
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
-    if current.gifUrl == "assets/waiting.gif" 
-        then
-            -- If we're waiting for the first random gif, don't generate an entry ...
-            -- wait for the gif to arrive.
-            Nothing
-
-        else
-            Just (RouteHash.set [current.gifUrl])
+    if current.gifUrl == "assets/waiting.gif" then
+        -- If we're waiting for the first random gif, don't generate an entry ...
+        -- wait for the gif to arrive.
+        Nothing
+    else
+        Just (RouteHash.set [ current.gifUrl ])
 
 
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
-    if current.gifUrl == "assets/waiting.gif" 
-        then
-            -- If we're waiting for the first random gif, don't generate an entry ...
-            -- wait for the gif to arrive.
-            Nothing
-
-        else
-            builder
-            |> appendToPath [current.gifUrl]
+    if current.gifUrl == "assets/waiting.gif" then
+        -- If we're waiting for the first random gif, don't generate an entry ...
+        -- wait for the gif to arrive.
+        Nothing
+    else
+        builder
+            |> appendToPath [ current.gifUrl ]
             |> Just
 
 

--- a/examples/elm-architecture-tutorial/Example6/RandomGifPair.elm
+++ b/examples/elm-architecture-tutorial/Example6/RandomGifPair.elm
@@ -2,14 +2,13 @@ module Example6.RandomGifPair exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.App exposing (map)
 import RouteHash exposing (HashUpdate)
 import RouteUrl.Builder exposing (Builder, path, appendToPath)
-
 import Example6.RandomGif as RandomGif
 
 
 -- MODEL
+
 
 type alias Model =
     { left : RandomGif.Model
@@ -17,58 +16,75 @@ type alias Model =
     }
 
 
+
 -- Rewrote to move initialization strings from Main.elm
-init : (Model, Cmd Action)
+
+
+init : ( Model, Cmd Action )
 init =
-  let
-    leftTopic = "funny cats"
-    rightTopic = "funny dogs"
-    (left, leftFx) = RandomGif.init leftTopic
-    (right, rightFx) = RandomGif.init rightTopic
-  in
-    ( Model left right
-    , Cmd.batch
-        [ Cmd.map Left leftFx
-        , Cmd.map Right rightFx
-        ]
-    )
+    let
+        leftTopic =
+            "funny cats"
+
+        rightTopic =
+            "funny dogs"
+
+        ( left, leftFx ) =
+            RandomGif.init leftTopic
+
+        ( right, rightFx ) =
+            RandomGif.init rightTopic
+    in
+        ( Model left right
+        , Cmd.batch
+            [ Cmd.map Left leftFx
+            , Cmd.map Right rightFx
+            ]
+        )
+
 
 
 -- UPDATE
+
 
 type Action
     = Left RandomGif.Action
     | Right RandomGif.Action
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update action model =
-  case action of
-    Left act ->
-      let
-        (left, fx) = RandomGif.update act model.left
-      in
-        ( Model left model.right
-        , Cmd.map Left fx
-        )
+    case action of
+        Left act ->
+            let
+                ( left, fx ) =
+                    RandomGif.update act model.left
+            in
+                ( Model left model.right
+                , Cmd.map Left fx
+                )
 
-    Right act ->
-      let
-        (right, fx) = RandomGif.update act model.right
-      in
-        ( Model model.left right
-        , Cmd.map Right fx
-        )
+        Right act ->
+            let
+                ( right, fx ) =
+                    RandomGif.update act model.right
+            in
+                ( Model model.left right
+                , Cmd.map Right fx
+                )
+
 
 
 -- VIEW
 
+
 view : Model -> Html Action
 view model =
-  div [ style [ ("display", "flex") ] ]
-    [ map Left (RandomGif.view model.left)
-    , map Right (RandomGif.view model.right)
-    ]
+    div [ style [ ( "display", "flex" ) ] ]
+        [ Html.map Left (RandomGif.view model.left)
+        , Html.map Right (RandomGif.view model.right)
+        ]
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
@@ -76,11 +92,16 @@ view model =
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction. Or, you could track the title in the higher level module,
 -- if you prefer that.
+
+
 title : String
-title = "Pair of Random Gifs"
+title =
+    "Pair of Random Gifs"
+
 
 
 -- Routing (Old API)
+
 
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
@@ -92,18 +113,19 @@ delta2update previous current =
         right =
             Maybe.map RouteHash.extract <|
                 RandomGif.delta2update previous.right current.right
-
     in
         -- Essentially, we want to combine left and right. I should think about
         -- how to improve the API for this. We can simplify in this case because
         -- we happen to know that both sides will be lists of length 1. If the
         -- lengths could vary, we'd have to do something more complex.
-        Maybe.map RouteHash.set <|
-            left `Maybe.andThen` (\l ->
-                right `Maybe.andThen` (\r ->
-                    Just (l ++ r)
+        left
+            |> Maybe.andThen
+                (\l ->
+                    right
+                        |> Maybe.andThen
+                            (\r -> Just (l ++ r))
                 )
-            )
+            |> Maybe.map RouteHash.set
 
 
 location2action : List String -> List Action
@@ -114,15 +136,17 @@ location2action list =
     case list of
         left :: right :: rest ->
             List.concat
-                [ List.map Left <| RandomGif.location2action [left]
-                , List.map Right <| RandomGif.location2action [right]
+                [ List.map Left <| RandomGif.location2action [ left ]
+                , List.map Right <| RandomGif.location2action [ right ]
                 ]
 
         _ ->
             []
 
 
+
 -- Routing (New API)
+
 
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
@@ -132,14 +156,17 @@ delta2builder previous current =
 
         right =
             RandomGif.delta2builder previous.right current.right
-
     in
         -- Essentially, we want to combine left and right.
-        left `Maybe.andThen` (\l ->
-            right `Maybe.andThen` (\r ->
-                Just <| appendToPath (path r) l
-            )
-        )
+        left
+            |> Maybe.andThen
+                (\l ->
+                    right
+                        |> Maybe.andThen
+                            (\r ->
+                                Just <| appendToPath (path r) l
+                            )
+                )
 
 
 builder2messages : Builder -> List Action
@@ -150,8 +177,8 @@ builder2messages builder =
     case path builder of
         left :: right :: rest ->
             List.concat
-                [ List.map Left <| RandomGif.location2action [left]
-                , List.map Right <| RandomGif.location2action [right]
+                [ List.map Left <| RandomGif.location2action [ left ]
+                , List.map Right <| RandomGif.location2action [ right ]
                 ]
 
         _ ->

--- a/examples/elm-architecture-tutorial/Example7/RandomGif.elm
+++ b/examples/elm-architecture-tutorial/Example7/RandomGif.elm
@@ -9,120 +9,151 @@ import Task
 
 
 -- MODEL
-
 -- In the advanced example, it's easier to track the gifUrl as a Maybe String
 -- and apply the default value later, since the default value is really a
 -- question for the view, rather than the model.
+
+
 type alias Model =
     { topic : String
     , gifUrl : Maybe String
     }
 
 
+
 -- We provide for initializing with the gifUrl already set, since that is how
 -- the routing will do it. If the gifUrl is provided, then we skip getting a
 -- random one.
-init : String -> Maybe String -> (Model, Cmd Action)
+
+
+init : String -> Maybe String -> ( Model, Cmd Action )
 init topic gifUrl =
-  ( Model topic gifUrl
-  , if gifUrl == Nothing
-        then getRandomGif topic
-        else Cmd.none
-  )
+    ( Model topic gifUrl
+    , if gifUrl == Nothing then
+        getRandomGif topic
+      else
+        Cmd.none
+    )
+
 
 
 -- UPDATE
 
+
 type Action
     = RequestMore
-    | HttpError Http.Error
-    | NewGif String
+    | NewGif (Result Http.Error String)
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update action model =
-  case action of
-    RequestMore ->
-      (model, getRandomGif model.topic)
+    case action of
+        RequestMore ->
+            ( model, getRandomGif model.topic )
 
-    NewGif url ->
-      ( Model model.topic (Just url)
-      , Cmd.none
-      )
+        NewGif (Ok url) ->
+            ( Model model.topic (Just url)
+            , Cmd.none
+            )
 
-    HttpError error ->
-      -- Should really show the error ... do nothing for now.
-      ( model, Cmd.none )
+        NewGif (Err _) ->
+            -- Should really show the error ... do nothing for now.
+            ( model, Cmd.none )
+
 
 
 -- VIEW
 
-(=>) = (,)
+
+(=>) =
+    (,)
 
 
 view : Model -> Html Action
 view model =
-  div [ style [ "width" => "200px" ] ]
-    [ h2 [headerStyle] [text model.topic]
-    , div [imgStyle (Maybe.withDefault "assets/waiting.gif" model.gifUrl)] []
-    , button [ onClick RequestMore ] [ text "More Please!" ]
-    ]
+    div [ style [ "width" => "200px" ] ]
+        [ h2 [ headerStyle ] [ text model.topic ]
+        , div [ imgStyle (Maybe.withDefault "assets/waiting.gif" model.gifUrl) ] []
+        , button [ onClick RequestMore ] [ text "More Please!" ]
+        ]
 
 
 headerStyle : Attribute any
 headerStyle =
-  style
-    [ "width" => "200px"
-    , "text-align" => "center"
-    ]
+    style
+        [ "width" => "200px"
+        , "text-align" => "center"
+        ]
 
 
 imgStyle : String -> Attribute any
 imgStyle url =
-  style
-    [ "display" => "inline-block"
-    , "width" => "200px"
-    , "height" => "200px"
-    , "background-position" => "center center"
-    , "background-size" => "cover"
-    , "background-image" => ("url('" ++ url ++ "')")
-    ]
+    style
+        [ "display" => "inline-block"
+        , "width" => "200px"
+        , "height" => "200px"
+        , "background-position" => "center center"
+        , "background-size" => "cover"
+        , "background-image" => ("url('" ++ url ++ "')")
+        ]
+
 
 
 -- EFFECTS
 
+
+urlWithArgs : String -> List (String, String) -> String
+urlWithArgs baseUrl args =
+  case args of
+    [] ->
+        baseUrl
+
+    _ ->
+        baseUrl ++ "?" ++ String.join "&" (List.map queryPair args)
+
+
+queryPair : (String,String) -> String
+queryPair (key,value) =
+  queryEscape key ++ "=" ++ queryEscape value
+
+
+queryEscape : String -> String
+queryEscape string =
+  String.join "+" (String.split "%20" (Http.encodeUri string))
+
+
 getRandomGif : String -> Cmd Action
 getRandomGif topic =
-  Http.get decodeUrl (randomUrl topic)
-    |> Task.perform HttpError NewGif
+    Http.send NewGif <|
+        Http.get (randomUrl topic) decodeUrl
 
 
 randomUrl : String -> String
 randomUrl topic =
-  Http.url "http://api.giphy.com/v1/gifs/random"
-    [ "api_key" => "dc6zaTOxFJmzC"
-    , "tag" => topic
-    ]
+    urlWithArgs "http://api.giphy.com/v1/gifs/random"
+        [ "api_key" => "dc6zaTOxFJmzC"
+        , "tag" => topic
+        ]
 
 
 decodeUrl : Json.Decoder String
 decodeUrl =
-  Json.at ["data", "image_url"] Json.string
+    Json.at [ "data", "image_url" ] Json.string
+
 
 
 -- Routing
-
 -- Instead of using the same signature all the way down, we'll simplify this
 -- case a little.
+
+
 encodeLocation : Model -> Maybe (List String)
 encodeLocation model =
     -- Don't encode if there's no gifUrl
-    if (model.gifUrl == Nothing)
-        then
-            Nothing
-
-        else
-            Just
-                [ model.topic
-                , Maybe.withDefault "" model.gifUrl
-                ]
+    if (model.gifUrl == Nothing) then
+        Nothing
+    else
+        Just
+            [ model.topic
+            , Maybe.withDefault "" model.gifUrl
+            ]

--- a/examples/elm-architecture-tutorial/Example8/SpinSquare.elm
+++ b/examples/elm-architecture-tutorial/Example8/SpinSquare.elm
@@ -1,9 +1,8 @@
-module Example8.SpinSquare exposing
-    (Model, Action, init, update, view, delta2update, location2action, subscriptions)
+module Example8.SpinSquare exposing (Model, Action, init, update, view, delta2update, location2action, subscriptions)
 
 import Ease exposing (outBounce)
 import Html exposing (Html)
-import Svg exposing (svg, rect, g, text, text')
+import Svg exposing (svg, rect, g, text, text_)
 import Svg.Attributes exposing (..)
 import Svg.Events exposing (onClick)
 import Time exposing (Time, second)
@@ -13,6 +12,7 @@ import String
 
 
 -- MODEL
+
 
 type alias Model =
     { angle : Float
@@ -26,20 +26,26 @@ type alias AnimationState =
     }
 
 
-init : (Model, Cmd Action)
+init : ( Model, Cmd Action )
 init =
-  ( { angle = 0, animationState = Nothing }
-  , Cmd.none
-  )
+    ( { angle = 0, animationState = Nothing }
+    , Cmd.none
+    )
 
 
-rotateStep = 90
-duration = second
+rotateStep =
+    90
+
+
+duration =
+    second
+
 
 
 -- UPDATE
-
 -- For the advanced example, allow setting the angle directly
+
+
 type Action
     = Spin
     | Tick Time
@@ -56,116 +62,120 @@ subscriptions model =
             Sub.none
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update msg model =
-  case msg of
-    Spin ->
-      case model.animationState of
-        Nothing ->
-          ( { model |
-                animationState = Just
-                    { elapsedTime = 0
-                    , step = rotateStep
-                    }
-            }
-          , Cmd.none
-          )
+    case msg of
+        Spin ->
+            case model.animationState of
+                Nothing ->
+                    ( { model
+                        | animationState =
+                            Just
+                                { elapsedTime = 0
+                                , step = rotateStep
+                                }
+                      }
+                    , Cmd.none
+                    )
 
-        Just _ ->
-          ( model, Cmd.none )
+                Just _ ->
+                    ( model, Cmd.none )
 
-    Tick diff ->
-        case model.animationState of
-            Nothing ->
-                -- We weren't expecting a tick, so this is just a stray
-                (model, Cmd.none)
+        Tick diff ->
+            case model.animationState of
+                Nothing ->
+                    -- We weren't expecting a tick, so this is just a stray
+                    ( model, Cmd.none )
 
-            Just animation ->
-                let
-                    newElapsedTime =
-                        animation.elapsedTime + diff
+                Just animation ->
+                    let
+                        newElapsedTime =
+                            animation.elapsedTime + diff
+                    in
+                        if newElapsedTime > duration then
+                            -- The animation is finished, so actually update the
+                            -- model by changing the angle.
+                            ( { angle = model.angle + animation.step
+                              , animationState = Nothing
+                              }
+                            , Cmd.none
+                            )
+                        else
+                            -- We're still animating, so update the time and let
+                            -- the view take care of drawing.
+                            ( { angle = model.angle
+                              , animationState = Just { animation | elapsedTime = newElapsedTime }
+                              }
+                            , Cmd.none
+                            )
 
-                in
-                    if newElapsedTime > duration then
-                        -- The animation is finished, so actually update the
-                        -- model by changing the angle.
-                        ( { angle = model.angle + animation.step
-                          , animationState = Nothing
-                          }
-                        , Cmd.none
-                        )
-                    else
-                        -- We're still animating, so update the time and let
-                        -- the view take care of drawing.
-                        ( { angle = model.angle
-                          , animationState = Just { animation | elapsedTime = newElapsedTime }
-                          }
-                        , Cmd.none
-                        )
+        SetAngle angle ->
+            ( { model
+                | animationState =
+                    Just
+                        { elapsedTime = 0
+                        , step = angle - model.angle
+                        }
+              }
+            , Cmd.none
+            )
 
-    SetAngle angle ->
-        ( { model |
-                animationState = Just
-                    { elapsedTime = 0
-                    , step = angle - model.angle
-                    }
-          }
-        , Cmd.none
-        )
 
 
 -- VIEW
 
+
 toOffset : Maybe AnimationState -> Float
 toOffset animationState =
-  case animationState of
-    Nothing ->
-      0
+    case animationState of
+        Nothing ->
+            0
 
-    Just animation ->
-      (outBounce (animation.elapsedTime / duration)) * animation.step
+        Just animation ->
+            (outBounce (animation.elapsedTime / duration)) * animation.step
 
 
 view : Model -> Html Action
 view model =
-  let
-    angle =
-      model.angle + toOffset model.animationState
-  in
-    svg
-      [ width "200", height "200", viewBox "0 0 200 200" ]
-      [ g [ transform ("translate(100, 100) rotate(" ++ toString angle ++ ")")
-          , onClick Spin
-          ]
-          [ rect
-              [ x "-50"
-              , y "-50"
-              , width "100"
-              , height "100"
-              , rx "15"
-              , ry "15"
-              , style "fill: #60B5CC;"
-              ]
-              []
-          , text' [ fill "white", textAnchor "middle" ] [ text "Click me!" ]
-          ]
-      ]
+    let
+        angle =
+            model.angle + toOffset model.animationState
+    in
+        svg
+            [ width "200", height "200", viewBox "0 0 200 200" ]
+            [ g
+                [ transform ("translate(100, 100) rotate(" ++ toString angle ++ ")")
+                , onClick Spin
+                ]
+                [ rect
+                    [ x "-50"
+                    , y "-50"
+                    , width "100"
+                    , height "100"
+                    , rx "15"
+                    , ry "15"
+                    , style "fill: #60B5CC;"
+                    ]
+                    []
+                , text_ [ fill "white", textAnchor "middle" ] [ text "Click me!" ]
+                ]
+            ]
+
 
 
 -- Routing
-
 -- Again, we don't necessarily need to use the same signature always ...
+
+
 delta2update : Model -> Maybe String
 delta2update current =
     -- We only want to update if our animation state is Nothing, since
     -- we don't want to set the history for every animation step
-    if current.animationState == Nothing
-        then
-            Just <|
-                toString current.angle
-
-        else
-            Nothing
+    if current.animationState == Nothing then
+        Just <|
+            toString current.angle
+    else
+        Nothing
 
 
 location2action : String -> Maybe Action

--- a/examples/elm-architecture-tutorial/Example8/SpinSquarePair.elm
+++ b/examples/elm-architecture-tutorial/Example8/SpinSquarePair.elm
@@ -2,7 +2,6 @@ module Example8.SpinSquarePair exposing (..)
 
 import Html exposing (..)
 import Html.Attributes exposing (..)
-import Html.App exposing (map)
 import Example8.SpinSquare as SpinSquare
 import RouteHash exposing (HashUpdate)
 import RouteUrl.Builder as Builder exposing (Builder, builder, insertQuery, getQuery)
@@ -10,27 +9,33 @@ import RouteUrl.Builder as Builder exposing (Builder, builder, insertQuery, getQ
 
 -- MODEL
 
+
 type alias Model =
     { left : SpinSquare.Model
     , right : SpinSquare.Model
     }
 
 
-init : (Model, Cmd Action)
+init : ( Model, Cmd Action )
 init =
-  let
-    (left, leftFx) = SpinSquare.init
-    (right, rightFx) = SpinSquare.init
-  in
-    ( Model left right
-    , Cmd.batch
-        [ Cmd.map Left leftFx
-        , Cmd.map Right rightFx
-        ]
-    )
+    let
+        ( left, leftFx ) =
+            SpinSquare.init
+
+        ( right, rightFx ) =
+            SpinSquare.init
+    in
+        ( Model left right
+        , Cmd.batch
+            [ Cmd.map Left leftFx
+            , Cmd.map Right rightFx
+            ]
+        )
+
 
 
 -- UPDATE
+
 
 type Action
     = Left SpinSquare.Action
@@ -45,38 +50,43 @@ subscriptions model =
         ]
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update action model =
-  case action of
-    Left act ->
-      let
-        (left, fx) = SpinSquare.update act model.left
-      in
-        ( Model left model.right
-        , Cmd.map Left fx
-        )
+    case action of
+        Left act ->
+            let
+                ( left, fx ) =
+                    SpinSquare.update act model.left
+            in
+                ( Model left model.right
+                , Cmd.map Left fx
+                )
 
-    Right act ->
-      let
-        (right, fx) = SpinSquare.update act model.right
-      in
-        ( Model model.left right
-        , Cmd.map Right fx
-        )
+        Right act ->
+            let
+                ( right, fx ) =
+                    SpinSquare.update act model.right
+            in
+                ( Model model.left right
+                , Cmd.map Right fx
+                )
 
 
 
 -- VIEW
 
-(=>) = (,)
+
+(=>) =
+    (,)
 
 
 view : Model -> Html Action
 view model =
-  div [ style [ "display" => "flex" ] ]
-    [ map Left (SpinSquare.view model.left)
-    , map Right (SpinSquare.view model.right)
-    ]
+    div [ style [ "display" => "flex" ] ]
+        [ Html.map Left (SpinSquare.view model.left)
+        , Html.map Right (SpinSquare.view model.right)
+        ]
+
 
 
 -- We add a separate function to get a title, which the ExampleViewer uses to
@@ -84,13 +94,18 @@ view model =
 -- kind return `Html` instead, depending on where it makes sense to do some of
 -- the construction. Or, you could track the title in the higher level module,
 -- if you prefer that.
+
+
 title : String
-title = "Pair of spinning squares"
+title =
+    "Pair of spinning squares"
+
 
 
 -- Routing
-
 -- Old `RouteHash` API
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     let
@@ -99,17 +114,23 @@ delta2update previous current =
 
         right =
             SpinSquare.delta2update current.right
-
     in
-        left `Maybe.andThen` (\l ->
-            right `Maybe.andThen` (\r ->
-                Just <|
-                    RouteHash.set [l, r]
-            )
-        )
+        left
+            |> Maybe.andThen
+                (\l ->
+                    right
+                        |> Maybe.andThen
+                            (\r ->
+                                Just <|
+                                    RouteHash.set [ l, r ]
+                            )
+                )
+
 
 
 -- Old `RouteHash` API
+
+
 location2action : List String -> List Action
 location2action list =
     case list of
@@ -123,7 +144,10 @@ location2action list =
             []
 
 
+
 -- New `RouteUrl` API
+
+
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
     let
@@ -134,21 +158,27 @@ delta2builder previous current =
         right : Maybe String
         right =
             SpinSquare.delta2update current.right
-
     in
-        left `Maybe.andThen` (\l ->
-            right `Maybe.andThen` (\r ->
-                -- Since we can, why not use the query parameters?
-                Just (
-                    builder
-                    |> insertQuery "left" l
-                    |> insertQuery "right" r
+        left
+            |> Maybe.andThen
+                (\l ->
+                    right
+                        |> Maybe.andThen
+                            (\r ->
+                                -- Since we can, why not use the query parameters?
+                                Just
+                                    (builder
+                                        |> insertQuery "left" l
+                                        |> insertQuery "right" r
+                                    )
+                            )
                 )
-            )
-        )
+
 
 
 -- New `RouteUrl` API
+
+
 builder2messages : Builder -> List Action
 builder2messages builder =
     -- Remember that you can parse as you like ... this is just
@@ -159,10 +189,9 @@ builder2messages builder =
 
         right =
             getQuery "right" builder
-
     in
-        case (left, right) of
-            (Just l, Just r) ->
+        case ( left, right ) of
+            ( Just l, Just r ) ->
                 List.filterMap identity
                     [ Maybe.map Left <| SpinSquare.location2action l
                     , Maybe.map Right <| SpinSquare.location2action r

--- a/examples/elm-architecture-tutorial/ExampleViewer.elm
+++ b/examples/elm-architecture-tutorial/ExampleViewer.elm
@@ -1,9 +1,8 @@
 module ExampleViewer exposing (..)
 
-import Html exposing (Html, div, p, text, table, tr, td)
+import Html exposing (Html, div, p, text, table, tr, td, map)
 import Html.Attributes exposing (style)
 import Html.Events exposing (onClick)
-import Html.App exposing (map)
 import RouteHash exposing (HashUpdate)
 import RouteUrl exposing (UrlChange)
 import RouteUrl.Builder as Builder exposing (Builder)
@@ -16,9 +15,8 @@ import Navigation exposing (Location)
 -- record for each `Example` and some inter-related functions to use those
 -- records). But that can be a little hard to follow, so I thought I'd leave
 -- things a little more verbose here for now.
-
-
 -- Note that I'm renaming these locally for simplicity.
+
 import Example1.Counter as Example1
 import Example2.CounterPair as Example2
 import Example3.CounterList as Example3
@@ -30,8 +28,9 @@ import Example8.SpinSquarePair as Example8
 
 
 -- MODEL
-
 -- We'll need to know which example we're showing at the moment.
+
+
 type Example
     = Example1
     | Example2
@@ -41,6 +40,7 @@ type Example
     | Example6
     | Example7
     | Example8
+
 
 
 -- We need to collect all the data that each example wants to track. Now, we
@@ -55,6 +55,8 @@ type Example
 -- to be remembered, but only while the user is looking at a particular thing).
 -- So, in that cae, some things would be in a record, whereas other things would
 -- be in a union type.
+
+
 type alias Model =
     { example1 : Example1.Model
     , example2 : Example2.Model
@@ -63,15 +65,18 @@ type alias Model =
     , example5 : Example5.Model
     , example6 : Example6.Model
     , example7 : Example7.Model
-    , example8 : Example8.Model
-
-    -- And, we need to track which example we're actually showing
+    , example8 :
+        Example8.Model
+        -- And, we need to track which example we're actually showing
     , currentExample : Example
     }
 
 
+
 -- Now, to init our model, we have to collect each examples init
-init : (Model, Cmd Action)
+
+
+init : ( Model, Cmd Action )
 init =
     let
         model =
@@ -79,11 +84,10 @@ init =
             , example2 = Example2.init
             , example3 = Example3.init
             , example4 = Example4.init
-            , example5 = fst Example5.init
-            , example6 = fst Example6.init
-            , example7 = fst Example7.init
-            , example8 = fst Example8.init
-
+            , example5 = Tuple.first Example5.init
+            , example6 = Tuple.first Example6.init
+            , example7 = Tuple.first Example7.init
+            , example8 = Tuple.first Example8.init
             , currentExample = Example1
             }
 
@@ -91,25 +95,28 @@ init =
             Cmd.batch
                 -- We happen to know that examples 1 through 4
                 -- have no effects defined.
-                [ Cmd.map Example5Action <| snd Example5.init
-                , Cmd.map Example6Action <| snd Example6.init
-                , Cmd.map Example7Action <| snd Example7.init
-                , Cmd.map Example8Action <| snd Example8.init
+                [ Cmd.map Example5Action <| Tuple.second Example5.init
+                , Cmd.map Example6Action <| Tuple.second Example6.init
+                , Cmd.map Example7Action <| Tuple.second Example7.init
+                , Cmd.map Example8Action <| Tuple.second Example8.init
                 ]
-
     in
-        (model, effects)
+        ( model, effects )
+
 
 
 -- SUBSCRIPTIONS
-
 -- I happen to know that only Example8 uses them
+
+
 subscriptions : Model -> Sub Action
 subscriptions model =
     Sub.map Example8Action (Example8.subscriptions model.example8)
 
 
+
 -- UPDATE
+
 
 type Action
     = Example1Action Example1.Action
@@ -124,7 +131,7 @@ type Action
     | NoOp
 
 
-update : Action -> Model -> (Model, Cmd Action)
+update : Action -> Model -> ( Model, Cmd Action )
 update action model =
     case action of
         NoOp ->
@@ -159,45 +166,45 @@ update action model =
             let
                 result =
                     Example5.update subaction model.example5
-
             in
-                ( { model | example5 = fst result }
-                , Cmd.map Example5Action <| snd result
+                ( { model | example5 = Tuple.first result }
+                , Cmd.map Example5Action <| Tuple.second result
                 )
 
         Example6Action subaction ->
             let
                 result =
                     Example6.update subaction model.example6
-
             in
-                ( { model | example6 = fst result }
-                , Cmd.map Example6Action <| snd result
+                ( { model | example6 = Tuple.first result }
+                , Cmd.map Example6Action <| Tuple.second result
                 )
 
         Example7Action subaction ->
             let
                 result =
                     Example7.update subaction model.example7
-
             in
-                ( { model | example7 = fst result }
-                , Cmd.map Example7Action <| snd result
+                ( { model | example7 = Tuple.first result }
+                , Cmd.map Example7Action <| Tuple.second result
                 )
 
         Example8Action subaction ->
             let
                 result =
                     Example8.update subaction model.example8
-
             in
-                ( { model | example8 = fst result }
-                , Cmd.map Example8Action <| snd result
+                ( { model | example8 = Tuple.first result }
+                , Cmd.map Example8Action <| Tuple.second result
                 )
+
+
 
 -- VIEW
 
-(=>) = (,)
+
+(=>) =
+    (,)
 
 
 view : Model -> Html Action
@@ -229,34 +236,36 @@ view model =
                 Example8 ->
                     map Example8Action (Example8.view model.example8)
 
-        makeTitle (index, example, title) =
+        makeTitle ( index, example, title ) =
             let
                 styleList =
-                    if example == model.currentExample
-                        then
-                            [ "font-weight" => "bold"
-                            ]
-                        else
-                            [ "font-weight" => "normal"
-                            , "color" => "blue"
-                            , "cursor" => "pointer"
-                            ]
+                    if example == model.currentExample then
+                        [ "font-weight" => "bold"
+                        ]
+                    else
+                        [ "font-weight" => "normal"
+                        , "color" => "blue"
+                        , "cursor" => "pointer"
+                        ]
 
                 -- Note that we compose the full title out of some information the
                 -- super-module knows about (the index) and some information the
                 -- sub-module knows about (the title)
                 fullTitle =
                     text <|
-                        "Example " ++ (toString index) ++ ": " ++ title
+                        "Example "
+                            ++ (toString index)
+                            ++ ": "
+                            ++ title
 
                 -- If we're already on a page, we don't have a click action
                 clickAction =
-                    if example == model.currentExample
-                        then []
-                        else [ onClick (ShowExample example) ]
-
+                    if example == model.currentExample then
+                        []
+                    else
+                        [ onClick (ShowExample example) ]
             in
-                p   ( style styleList :: clickAction )
+                p (style styleList :: clickAction)
                     [ fullTitle ]
 
         toc =
@@ -271,7 +280,6 @@ view model =
                     , ( 7, Example7, Example7.title )
                     , ( 8, Example8, Example8.title )
                     ]
-
     in
         table []
             [ tr []
@@ -298,19 +306,18 @@ view model =
             ]
 
 
--- ROUTING
 
+-- ROUTING
 -- I've include demo code here for the old API, as well as the new API
 -- using the full URL or just using the hash. Just to be completely clear,
 -- you don't need all of these in practice ... you just pick one!
-
-
 --------------------
 -- Old RouteHash API
 --------------------
-
 -- If you have existing code using elm-route-hash, your `delta2update` function
 -- should not require any changes.
+
+
 delta2update : Model -> Model -> Maybe HashUpdate
 delta2update previous current =
     case current.currentExample of
@@ -349,9 +356,12 @@ delta2update previous current =
                 Example8.delta2update previous.example8 current.example8
 
 
+
 -- Here, we basically do the reverse of what delta2update does. If you
 -- have existing code using elm-route-hash, your `location2action` function
 -- should not require any changes.
+
+
 location2action : List String -> List Action
 location2action list =
     case list of
@@ -359,28 +369,28 @@ location2action list =
             -- We give the Example1 module a chance to interpret the rest of
             -- the URL, and then we prepend an action for the part we
             -- interpreted.
-            ( ShowExample Example1 ) :: List.map Example1Action ( Example1.location2action rest )
+            (ShowExample Example1) :: List.map Example1Action (Example1.location2action rest)
 
         "example-2" :: rest ->
-            ( ShowExample Example2 ) :: List.map Example2Action ( Example2.location2action rest )
+            (ShowExample Example2) :: List.map Example2Action (Example2.location2action rest)
 
         "example-3" :: rest ->
-            ( ShowExample Example3 ) :: List.map Example3Action ( Example3.location2action rest )
+            (ShowExample Example3) :: List.map Example3Action (Example3.location2action rest)
 
         "example-4" :: rest ->
-            ( ShowExample Example4 ) :: List.map Example4Action ( Example4.location2action rest )
+            (ShowExample Example4) :: List.map Example4Action (Example4.location2action rest)
 
         "example-5" :: rest ->
-            ( ShowExample Example5 ) :: List.map Example5Action ( Example5.location2action rest )
+            (ShowExample Example5) :: List.map Example5Action (Example5.location2action rest)
 
         "example-6" :: rest ->
-            ( ShowExample Example6 ) :: List.map Example6Action ( Example6.location2action rest )
+            (ShowExample Example6) :: List.map Example6Action (Example6.location2action rest)
 
         "example-7" :: rest ->
-            ( ShowExample Example7 ) :: List.map Example7Action ( Example7.location2action rest )
+            (ShowExample Example7) :: List.map Example7Action (Example7.location2action rest)
 
         "example-8" :: rest ->
-            ( ShowExample Example8 ) :: List.map Example8Action ( Example8.location2action rest )
+            (ShowExample Example8) :: List.map Example8Action (Example8.location2action rest)
 
         _ ->
             -- Normally, you'd want to show an error of some kind here.
@@ -392,8 +402,9 @@ location2action list =
 -------------------
 -- New RouteUrl API
 -------------------
-
 -- This is an example of the new API, if using the whole URL
+
+
 delta2url : Model -> Model -> Maybe UrlChange
 delta2url previous current =
     -- We're using a `Builder` to build up the possible change. You don't
@@ -404,7 +415,10 @@ delta2url previous current =
         delta2builder previous current
 
 
+
 -- An example of the new API, if just using the hash
+
+
 delta2hash : Model -> Model -> Maybe UrlChange
 delta2hash previous current =
     -- Here, we're re-using the Builder-oriented code, but stuffing everything
@@ -413,8 +427,11 @@ delta2hash previous current =
         delta2builder previous current
 
 
+
 -- This is the common code that we rely on above. Again, you don't have to use
 -- a `Builder` if you don't want to ... it's just one way to construct a `UrlChange`.
+
+
 delta2builder : Model -> Model -> Maybe Builder
 delta2builder previous current =
     case current.currentExample of
@@ -422,39 +439,42 @@ delta2builder previous current =
             -- First, we ask the submodule for a `Maybe Builder`. Then, we use
             -- `map` to prepend something to the path.
             Example1.delta2builder previous.example1 current.example1
-            |> Maybe.map (Builder.prependToPath ["example-1"])
+                |> Maybe.map (Builder.prependToPath [ "example-1" ])
 
         Example2 ->
             Example2.delta2builder previous.example2 current.example2
-            |> Maybe.map (Builder.prependToPath ["example-2"])
+                |> Maybe.map (Builder.prependToPath [ "example-2" ])
 
         Example3 ->
             Example3.delta2builder previous.example3 current.example3
-            |> Maybe.map (Builder.prependToPath ["example-3"])
+                |> Maybe.map (Builder.prependToPath [ "example-3" ])
 
         Example4 ->
             Example4.delta2builder previous.example4 current.example4
-            |> Maybe.map (Builder.prependToPath ["example-4"])
+                |> Maybe.map (Builder.prependToPath [ "example-4" ])
 
         Example5 ->
             Example5.delta2builder previous.example5 current.example5
-            |> Maybe.map (Builder.prependToPath ["example-5"])
+                |> Maybe.map (Builder.prependToPath [ "example-5" ])
 
         Example6 ->
             Example6.delta2builder previous.example6 current.example6
-            |> Maybe.map (Builder.prependToPath ["example-6"])
+                |> Maybe.map (Builder.prependToPath [ "example-6" ])
 
         Example7 ->
             Example7.delta2builder previous.example7 current.example7
-            |> Maybe.map (Builder.prependToPath ["example-7"])
+                |> Maybe.map (Builder.prependToPath [ "example-7" ])
 
         Example8 ->
             Example8.delta2builder previous.example8 current.example8
-            |> Maybe.map (Builder.prependToPath ["example-8"])
+                |> Maybe.map (Builder.prependToPath [ "example-8" ])
+
 
 
 -- This is an example of a `location2messages` function ... I'm calling it
 -- `url2messages` to illustrate something that uses the full URL.
+
+
 url2messages : Location -> List Action
 url2messages location =
     -- You can parse the `Location` in whatever way you want. I'm making
@@ -464,8 +484,11 @@ url2messages location =
     builder2messages (Builder.fromUrl location.href)
 
 
+
 -- This is an example of a `location2messages` function ... I'm calling it
 -- `hash2messages` to illustrate something that uses just the hash.
+
+
 hash2messages : Location -> List Action
 hash2messages location =
     -- You can parse the `Location` in whatever way you want. I'm making
@@ -475,7 +498,10 @@ hash2messages location =
     builder2messages (Builder.fromHash location.href)
 
 
+
 -- Another example of a `location2messages` function, this time only using the hash.
+
+
 builder2messages : Builder -> List Action
 builder2messages builder =
     -- You can parse the `Location` in whatever way you want ... there are a
@@ -487,40 +513,39 @@ builder2messages builder =
             let
                 subBuilder =
                     Builder.replacePath rest builder
-
             in
                 case first of
                     "example-1" ->
                         -- We give the Example1 module a chance to interpret
                         -- the rest of the location, and then we prepend an
                         -- action for the part we interpreted.
-                        ( ShowExample Example1 ) :: List.map Example1Action ( Example1.builder2messages subBuilder )
+                        (ShowExample Example1) :: List.map Example1Action (Example1.builder2messages subBuilder)
 
                     "example-2" ->
-                        ( ShowExample Example2 ) :: List.map Example2Action ( Example2.builder2messages subBuilder )
+                        (ShowExample Example2) :: List.map Example2Action (Example2.builder2messages subBuilder)
 
                     "example-3" ->
-                        ( ShowExample Example3 ) :: List.map Example3Action ( Example3.builder2messages subBuilder )
+                        (ShowExample Example3) :: List.map Example3Action (Example3.builder2messages subBuilder)
 
                     "example-4" ->
-                        ( ShowExample Example4 ) :: List.map Example4Action ( Example4.builder2messages subBuilder )
+                        (ShowExample Example4) :: List.map Example4Action (Example4.builder2messages subBuilder)
 
                     "example-5" ->
-                        ( ShowExample Example5 ) :: List.map Example5Action ( Example5.builder2messages subBuilder )
+                        (ShowExample Example5) :: List.map Example5Action (Example5.builder2messages subBuilder)
 
                     "example-6" ->
-                        ( ShowExample Example6 ) :: List.map Example6Action ( Example6.builder2messages subBuilder )
+                        (ShowExample Example6) :: List.map Example6Action (Example6.builder2messages subBuilder)
 
                     "example-7" ->
-                        ( ShowExample Example7 ) :: List.map Example7Action ( Example7.builder2messages subBuilder )
+                        (ShowExample Example7) :: List.map Example7Action (Example7.builder2messages subBuilder)
 
                     "example-8" ->
-                        ( ShowExample Example8 ) :: List.map Example8Action ( Example8.builder2messages subBuilder )
+                        (ShowExample Example8) :: List.map Example8Action (Example8.builder2messages subBuilder)
 
                     _ ->
-                    -- Normally, you'd want to show an error of some kind here.
-                    -- But, for the moment, I'll just default to example1
-                    [ ShowExample Example1 ]
+                        -- Normally, you'd want to show an error of some kind here.
+                        -- But, for the moment, I'll just default to example1
+                        [ ShowExample Example1 ]
 
         _ ->
             -- Normally, you'd want to show an error of some kind here.

--- a/examples/elm-architecture-tutorial/MainWithFullUrl.elm
+++ b/examples/elm-architecture-tutorial/MainWithFullUrl.elm
@@ -1,8 +1,10 @@
+module Main exposing (..)
+
 import ExampleViewer
 import RouteUrl
 
 
-main : Program Never
+main : Program Never (RouteUrl.Model ExampleViewer.Model) (RouteUrl.Msg ExampleViewer.Action)
 main =
     RouteUrl.program
         { delta2url = ExampleViewer.delta2url

--- a/examples/elm-architecture-tutorial/MainWithJustHash.elm
+++ b/examples/elm-architecture-tutorial/MainWithJustHash.elm
@@ -1,8 +1,10 @@
+module Main exposing (..)
+
 import ExampleViewer
 import RouteUrl
 
 
-main : Program Never
+main : Program Never (RouteUrl.Model ExampleViewer.Model) (RouteUrl.Msg ExampleViewer.Action)
 main =
     RouteUrl.program
         { delta2url = ExampleViewer.delta2hash

--- a/examples/elm-architecture-tutorial/MainWithOldAPI.elm
+++ b/examples/elm-architecture-tutorial/MainWithOldAPI.elm
@@ -1,8 +1,10 @@
+module Main exposing (..)
+
 import ExampleViewer
 import RouteHash
 
 
-main : Program Never
+main : Program Never (RouteHash.Model ExampleViewer.Model) (RouteHash.Msg ExampleViewer.Action)
 main =
     RouteHash.program
         { prefix = RouteHash.defaultPrefix

--- a/examples/elm-architecture-tutorial/elm-package.json
+++ b/examples/elm-architecture-tutorial/elm-package.json
@@ -9,6 +9,7 @@
     ],
     "exposed-modules": [],
     "dependencies": {
+        "ccapndave/elm-update-extra": "2.3.1 <= v < 3.0.0",
         "elm-community/easing-functions": "1.0.2 <= v < 2.0.0",
         "elm-community/result-extra": "2.0.1 <= v < 3.0.0",
         "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",

--- a/examples/elm-architecture-tutorial/elm-package.json
+++ b/examples/elm-architecture-tutorial/elm-package.json
@@ -9,15 +9,15 @@
     ],
     "exposed-modules": [],
     "dependencies": {
-        "elm-community/easing-functions": "1.0.1 <= v < 2.0.0",
-        "elm-community/result-extra": "1.0.0 <= v < 2.0.0",
-        "elm-lang/animation-frame": "1.0.0 <= v < 2.0.0",
-        "elm-lang/core": "4.0.1 <= v < 5.0.0",
-        "elm-lang/html": "1.0.0 <= v < 2.0.0",
-        "elm-lang/navigation": "1.0.0 <= v < 2.0.0",
-        "elm-lang/svg": "1.0.0 <= v < 2.0.0",
-        "evancz/elm-http": "3.0.1 <= v < 4.0.0",
-        "sporto/erl": "9.0.1 <= v < 10.0.0"
+        "elm-community/easing-functions": "1.0.2 <= v < 2.0.0",
+        "elm-community/result-extra": "2.0.1 <= v < 3.0.0",
+        "elm-lang/animation-frame": "1.0.1 <= v < 2.0.0",
+        "elm-lang/core": "5.0.0 <= v < 6.0.0",
+        "elm-lang/html": "2.0.0 <= v < 3.0.0",
+        "elm-lang/http": "1.0.0 <= v < 2.0.0",
+        "elm-lang/navigation": "2.0.0 <= v < 3.0.0",
+        "elm-lang/svg": "2.0.0 <= v < 3.0.0",
+        "sporto/erl": "10.0.2 <= v < 11.0.0"
     },
-    "elm-version": "0.17.0 <= v < 0.18.0"
+    "elm-version": "0.18.0 <= v < 0.19.0"
 }

--- a/src/RouteUrl.elm
+++ b/src/RouteUrl.elm
@@ -408,7 +408,9 @@ subscriptionsWithFlags app model =
 
 
 
--- This is the function which `Navigation` will use to tell us about a new location.
+-- This is the function which decides whether to tell the calling application's
+-- `location2messages` method if a really new location has been sent to
+-- us from outside the app.
 
 
 urlUpdateWithFlags : AppWithFlags model msg flags -> Location -> Model model -> ( Model model, Cmd (Msg msg) )
@@ -502,7 +504,9 @@ subscriptions app model =
 
 
 
--- This is the function which `Navigation` will use to tell us about a new location.
+-- This is the function which decides whether to tell the calling application's
+-- `location2messages` method if a really new location has been sent to
+-- us from outside the app.
 
 
 urlUpdate : App model msg -> Location -> Model model -> ( Model model, Cmd (Msg msg) )

--- a/src/RouteUrl.elm
+++ b/src/RouteUrl.elm
@@ -269,11 +269,11 @@ type Msg msg
 {-| A type which represents the various inputs to
 [`Navigation.program`](http://package.elm-lang.org/packages/elm-lang/navigation/2.0.0/Navigation#program).
 
-You can produce this via [`navigationApp`](#navigationApp). Then, you can supply 
+You can produce this via [`navigationApp`](#navigationApp). Then, you can supply
 this to [`runNavigationApp`](#runNavigationApp) in order to create a `Program`.
 
-Normally you don't need this -- you can just use [`program`](#program). 
-However, `NavigationApp` could be useful if you want to do any further wrapping 
+Normally you don't need this -- you can just use [`program`](#program).
+However, `NavigationApp` could be useful if you want to do any further wrapping
 of its functions.
 -}
 type alias NavigationApp model msg =
@@ -287,12 +287,12 @@ type alias NavigationApp model msg =
 {-| A type which represents the various inputs to
 [`Navigation.programWithFlags`](http://package.elm-lang.org/packages/elm-lang/navigation/2.0.0/Navigation#programWithFlags).
 
-You can produce this via [`navigationAppWithFlags`](#navigationAppWithFlags). 
-Then, you can supply this to [`runNavigationApp`](#runNavigationApp) in order 
+You can produce this via [`navigationAppWithFlags`](#navigationAppWithFlags).
+Then, you can supply this to [`runNavigationApp`](#runNavigationApp) in order
 to create a `Program flags`.
 
-Normally you don't need this -- you can just use 
-[`programWithFlags`](#programWithFlags). However, `NavigationAppWithFlags` 
+Normally you don't need this -- you can just use
+[`programWithFlags`](#programWithFlags). However, `NavigationAppWithFlags`
 could be useful if you want to do any further wrapping of its functions.
 -}
 type alias NavigationAppWithFlags model msg flags =
@@ -354,13 +354,13 @@ runNavigationApp app =
         }
 
 
-{-| Turns the output from [`navigationAppWithFlags`](#navigationAppWithFlags) 
+{-| Turns the output from [`navigationAppWithFlags`](#navigationAppWithFlags)
 into a `Program flags` that you can assign to your `main` function.
 
-For convenience, you will usually want to just use 
+For convenience, you will usually want to just use
 [`programWithFlags`](#programWithFlags), which goes directly from the required
-configuration to a `Program flags`. You would only want `runNavigationAppWithFlags` 
-for the sake of composability -- that is, in case there is something further 
+configuration to a `Program flags`. You would only want `runNavigationAppWithFlags`
+for the sake of composability -- that is, in case there is something further
 you want to do with the `NavigationApp` structure before turning it into a `Program flags`.
 -}
 runNavigationAppWithFlags : NavigationAppWithFlags model msg flags -> Program flags (Model model) (Msg msg)
@@ -437,6 +437,12 @@ init_ app location =
 -- from the initial location.
 
 
+initImpl
+    : (xmsg -> model -> ( model, Cmd msg ))
+    -> (Location -> List xmsg)
+    -> Location
+    -> ( model, Cmd msg )
+    -> ( Model model, Cmd (Msg msg) )
 initImpl upd l2m location ( userModelFromFlags, commandFromFlags ) =
     let
         locationMessages = l2m location
@@ -461,7 +467,12 @@ initImpl upd l2m location ( userModelFromFlags, commandFromFlags ) =
 -- returning the final state and any commands returned by the app's
 -- update function.
 
-
+processLocationMessages
+    : (xmsg -> model -> ( model, Cmd msg ))
+    -> List xmsg
+    -> model
+    -> List (Cmd msg)
+    -> ( model, List (Cmd msg) )
 processLocationMessages upd locationMessages userModel initialCommandList =
     let
         step msg (userModel, commandList) =
@@ -562,6 +573,13 @@ update_ app msg model =
 -- Common processing for the app's update function.
 
 
+updateImpl
+    : (xmsg -> model -> ( model, Cmd msg ))
+    -> ( Location -> List xmsg )
+    -> (model -> model -> Maybe UrlChange)
+    -> Msg xmsg
+    -> Model model
+    -> ( Model model, Cmd (Msg msg) )
 updateImpl upd l2m d2u msg model =
     case msg of
         RouterMsg location ->
@@ -606,6 +624,12 @@ updateImpl upd l2m d2u msg model =
 -- us from outside the app.
 
 
+urlUpdateImpl
+    : (xmsg -> model -> ( model, Cmd msg ))
+    -> (Location -> List xmsg)
+    -> Location
+    -> Model model
+    -> ( Model model, Cmd (Msg msg) )
 urlUpdateImpl upd l2m location model =
     let
         -- This is the same, no matter which path we follow below. Basically,


### PR DESCRIPTION
I gave myself an exercise to update your package to Elm 0.18.  I'm somewhat of an Elm newbie so I just could not get the "withFlags" and "withoutFlags" variants to compile following the way you extended AppWithFlags in your Elm 0.17 version. So you will see a lot of duplication of code.

The 5ef8746 commit actually compiled without all the unnecessary copying, but when I tried to run the examples in elm-reactor, I got this curious run-time message:

"Are you trying to sneak a Never value into Elm? Trickster!
It looks like Main.main is defined with `programWithFlags` but has type `Program Never`."

I guess because it doesn't the underlying program having flags, but being called as Program Never.

I also did a bit of copying in the examples, because the Elm 0.18 version of Http doesn't include the url method anymore. I grabbed the code from Elm 0.17 and put it inline in Examples 5, 6, and 7, renaming the method urlWithArgs. 
